### PR TITLE
add common.pxd, change some types

### DIFF
--- a/common.pxd
+++ b/common.pxd
@@ -1,0 +1,5 @@
+from fields cimport Field
+
+cdef:
+    Field *look_up(Field *grid, int N_x, int N_y, int N_z, int xx, int yy, int zz) nogil
+    void set_val(Field *grid, int N_x, int N_y, int N_z, int xx, int yy, int zz, Field *new_val) nogil

--- a/common.pyx
+++ b/common.pyx
@@ -1,14 +1,14 @@
 from fields cimport Field
 
-cdef Field look_up(Field *grid, int N_x, int N_y, int N_z,
-             int xx, int yy, int zz):
+cdef Field *look_up(Field *grid, int N_x, int N_y, int N_z,
+             int xx, int yy, int zz) nogil:
     """ Looks up the value at grid location (xx, yy, zz) in a 3-dimensional array grid of dimensions N_x, 
     N_y, and N_z assumed to be stored as a one dimensional array. """
 
-    return grid[xx + yy * N_x + zz * N_x * N_y]
+    return &(grid[xx + yy * N_x + zz * N_x * N_y])
 
 cdef void set_val(Field *grid, int N_x, int N_y, int N_z
-             int xx, int yy, int zz, Field new_val):
+             int xx, int yy, int zz, Field *new_val) nogil:
     """ Assigns grid[xx, yy, zz] to new_val """
 
-    grid[xx + yy * N_x + zz * N_x * N_y] = new_val
+    grid[xx + yy * N_x + zz * N_x * N_y] = *new_val

--- a/sim.pyx
+++ b/sim.pyx
@@ -2,10 +2,11 @@ from fields cimport Field
 cimport numpy as np
 from libc.stdlib cimport malloc, free
 from libc.stdio cimport fprintf, fopen, fclose, FILE
-from common import *
+from common cimport *
 from update_fields import *
 
 cpdef go(int N_x, int N_y, int N_z, int N_t,                                            # Number of grid points in each dimension
+         np.float64_t [:] initial_field_values,
          np.float64_t dx, np.float64_t dy, np.float64_t dz, np.float64_t dt,            # Time/spatial discretization
          np.float64_t mu, np.float64_t rho, np.float64_t lambd,                         # Material parameters
          np.float64_t t_0, np.float64_t t_f, np.float64_t [:] ts):#,                    # Initial and final time, list of time points
@@ -35,7 +36,7 @@ cpdef go(int N_x, int N_y, int N_z, int N_t,                                    
         for yy in range(N_y + 2):
             for zz in range(N_z + 2):
                 # grid[xx, yy, zz] = Field.__new__(Field)
-                set_val(grid, N_x, N_y, N_z, xx, yy, zz, *(<Field *> malloc(sizeof(Field))))
+                set_val(grid, N_x, N_y, N_z, xx, yy, zz, <Field *> initial_field_values)
 
     # Update the ghost regions to enforce periodicity
     set_up_ghost_regions(grid, N_x, N_y, N_z)


### PR DESCRIPTION
This fixes the common.pyx related errors.  There are a few more you'll need to address.

I've added a new argument to "go()", the initial field values for one field.  This should just be an array of float64 values in the same order as fields.pxd.

A couple of problems I noticed:
-  sim.pyx loops over (N_x + 2) (and y and z), which is larger than what you're allocating.
- fields.pyx has Field as a class, fields.pxd has it as a struct...  This seems iffy.
